### PR TITLE
GI-13 Add Admin to Users table

### DIFF
--- a/db/migrate/20181024114437_add_admin_to_users.rb
+++ b/db/migrate/20181024114437_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_18_101040) do
+ActiveRecord::Schema.define(version: 2018_10_24_114437) do
 
   create_table "ideas", force: :cascade do |t|
     t.integer "area_of_interest"
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 2018_10_18_101040) do
     t.string "unconfirmed_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
We need to be able to distinguish bewteen normal and admin users, the
simplist way of doing this for MVP is by adding a boolean to the users
table.  If more roles are required later we will address this then.