### PR TITLE
GI-9 Validate email is from justice.gov.uk domain

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  validates :email, presence: true, email: true
 end

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -1,0 +1,7 @@
+class EmailValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    unless value =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)*justice\.gov\.uk)\z/i
+      record.errors[attribute] << (options[:message] || "must end in justice.gov.uk")
+    end
+  end
+end

--- a/spec/controllers/ideas_controller_spec.rb
+++ b/spec/controllers/ideas_controller_spec.rb
@@ -27,7 +27,7 @@ require 'rails_helper'
 RSpec.describe IdeasController, type: :controller do
 
   let(:default_user){
-    User.create!(email:'me@me.com', password: 'change_me')
+    User.create!(email:'me@justice.gov.uk', password: 'change_me')
   }
   # This should return the minimal set of attributes required to create a valid
   # Idea. As you add validations to Idea, be sure to

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,5 +7,15 @@ RSpec.describe User, type: :model do
 
   describe "Validations" do
     it { should validate_presence_of(:email) }
+
+    it "should allow emails from justice.gov.uk domains" do
+      user = User.create!(email: 'me@justice.gov.uk', password: 'change_me')
+      expect(user).to be_valid
+    end
+
+    it "should not allow emails from non justice.gov.uk domains" do
+      user = User.create(email: 'me@gmail.com', password: 'change_me')
+      expect(user).to_not be_valid
+    end
   end
 end

--- a/spec/requests/ideas_spec.rb
+++ b/spec/requests/ideas_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Ideas", type: :request do
   describe "As a logged in user" do
 
     before do
-      @user = User.create!(email:'me@me.com', password: 'change_me')
+      @user = User.create!(email:'me@justice.gov.uk', password: 'change_me')
       sign_in @user
     end
 
@@ -114,7 +114,7 @@ RSpec.describe "Ideas", type: :request do
   describe "As an admin user who is logged in" do
 
     before do
-      @admin_user = User.create!(email:'admin@me.com', password: 'change_me', admin: true)
+      @admin_user = User.create!(email:'admin@justice.gov.uk', password: 'change_me', admin: true)
       sign_in @admin_user
     end
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 RSpec.describe "Users", type: :request do
 
   let(:default_user){
-    User.create!(email: 'me@me.com', password: 'change_me')
+    User.create!(email: 'me@justice.gov.uk', password: 'change_me')
   }
 
   let(:admin_user){
-    User.create!(email: 'admin@me.com', password: 'change_me', admin: true)
+    User.create!(email: 'admin@justice.gov.uk', password: 'change_me', admin: true)
   }
 
   describe "as a default user" do
@@ -40,8 +40,8 @@ RSpec.describe "Users", type: :request do
       it "returns a success response" do
         get users_path(default_user)
         expect(response).to be_successful
-        expect(response.body).to include('me@me.com')
-        expect(response.body).to include('admin@me.com')
+        expect(response.body).to include('me@justice.gov.uk')
+        expect(response.body).to include('admin@justice.gov.uk')
       end
     end
 
@@ -49,14 +49,14 @@ RSpec.describe "Users", type: :request do
       it "returns a success response" do
         get user_path(default_user)
         expect(response).to be_successful
-        expect(response.body).to include('me@me.com')
+        expect(response.body).to include('me@justice.gov.uk')
       end
     end
 
     describe "toggle admin" do
 
       it "updates to true if currently false" do
-        user = User.create!(email: 'test@test.com', password: 'change_me', admin: false)
+        user = User.create!(email: 'test@justice.gov.uk', password: 'change_me', admin: false)
         post user_toggle_admin_path(user)
         user.reload
         expect(user.admin).to be true
@@ -64,7 +64,7 @@ RSpec.describe "Users", type: :request do
       end
 
       it "updates to false if currently true" do
-        user = User.create!(email: 'test@test.com', password: 'change_me', admin: true)
+        user = User.create!(email: 'test@justice.gov.uk', password: 'change_me', admin: true)
         post user_toggle_admin_path(user)
         user.reload
         expect(user.admin).to be false

--- a/spec/system/assign_idea_spec.rb
+++ b/spec/system/assign_idea_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe "Assign idea", type: :system do
 
   before do
-    @user = User.create!(email:'me@me.com', password: 'change_me')
-    @admin_user = User.create!(email:'admin@me.com', password: 'change_me', admin: true)
+    @user = User.create!(email:'me@justice.gov.uk', password: 'change_me')
+    @admin_user = User.create!(email:'admin@justice.gov.uk', password: 'change_me', admin: true)
     @idea =  @user.ideas.create!(
         title: "Submit idea",
         area_of_interest: 0,

--- a/spec/system/idea_submission_spec.rb
+++ b/spec/system/idea_submission_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Ideas submission", type: :system do
 
   before do
-    @user = User.create!(email:'me@me.com', password: 'change_me')
+    @user = User.create!(email:'me@justice.gov.uk', password: 'change_me')
     sign_in @user
   end
 

--- a/spec/system/sign_up_spec.rb
+++ b/spec/system/sign_up_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "Sign up", type: :system do
+
+  describe "signing up as a new user" do
+    it "should allow .justice.gov.uk email addresses" do
+      visit new_user_registration_path
+      fill_in 'user_email', with: 'user@justice.gov.uk'
+      fill_in 'user_password', with: 'change_me'
+      fill_in 'user_password_confirmation', with: 'change_me'
+      click_button 'Sign up'
+      expect(page).to have_content 'Welcome! You have signed up successfully.'
+    end
+
+    it "should allow digital.justice.gov.uk email addresses" do
+      visit new_user_registration_path
+      fill_in 'user_email', with: 'user@digital.justice.gov.uk'
+      fill_in 'user_password', with: 'change_me'
+      fill_in 'user_password_confirmation', with: 'change_me'
+      click_button 'Sign up'
+      expect(page).to have_content 'Welcome! You have signed up successfully.'
+    end
+
+    it "should not allow non justice.gov.uk email addresses" do
+      visit new_user_registration_path
+      fill_in 'user_email', with: 'user@gmail.com'
+      fill_in 'user_password', with: 'change_me'
+      fill_in 'user_password_confirmation', with: 'change_me'
+      click_button 'Sign up'
+      expect(page).to have_content 'Email must end in justice.gov.uk'
+    end
+  end
+end

--- a/spec/system/user_admin_spec.rb
+++ b/spec/system/user_admin_spec.rb
@@ -3,13 +3,13 @@ require "rails_helper"
 RSpec.describe "User admin", type: :system do
 
   before do
-    @admin_user = User.create!(email:'me@me.com', password: 'change_me', admin: true)
+    @admin_user = User.create!(email:'me@justice.gov.uk', password: 'change_me', admin: true)
     sign_in @admin_user
   end
 
   describe "click the toggle admin button when user isn't an admin" do
     it "should set the user to be an admin" do
-      user = User.create!(email: 'admin@admin.com', password: 'change_me', admin: false)
+      user = User.create!(email: 'admin@justice.gov.uk', password: 'change_me', admin: false)
       visit user_path(user)
       click_button "Toggle Admin"
       user.reload
@@ -20,7 +20,7 @@ RSpec.describe "User admin", type: :system do
 
   describe "click the toggle admin button when user is an admin" do
     it "should set the user to not be an admin" do
-      user = User.create!(email: 'admin@admin.com', password: 'change_me', admin: true)
+      user = User.create!(email: 'admin@justice.gov.uk', password: 'change_me', admin: true)
       visit user_path(user)
       click_button "Toggle Admin"
       user.reload


### PR DESCRIPTION
When signing up the users email address should only be valid if the
email address is from the justice.gov.uk domain. This includes the
digital.justice.gov.uk domain and other subdomains.

To verify this validation in the real world, email confirmation will
need to be turned on in Devise.  This will be done in a separate PR.

Existing tests have been updated to use valid email addresses.