### PR TITLE
Feature/assigned ideas view

### DIFF
--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -5,7 +5,18 @@ class IdeasController < ApplicationController
   # GET /ideas
   # GET /ideas.json
   def index
-    @ideas = Idea.all
+    if params[:view]
+      view = params[:view]
+      if view.eql?("assigned")
+        @ideas = Idea.where(assigned_user_id: [current_user.id])
+      elsif view.eql?("submitted")
+        @ideas = Idea.where.not(submission_date: [nil, ""]).where(assigned_user_id: [nil, ""])
+      elsif view.eql?("user")
+        @ideas = current_user.ideas.all
+      end
+    else
+      @ideas = Idea.all
+    end  
   end
 
   # GET /ideas/1

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -5,18 +5,11 @@ class IdeasController < ApplicationController
   # GET /ideas
   # GET /ideas.json
   def index
-    if params[:view]
-      view = params[:view]
-      if view.eql?("assigned")
-        @ideas = Idea.where(assigned_user_id: [current_user.id])
-      elsif view.eql?("submitted")
-        @ideas = Idea.where.not(submission_date: [nil, ""]).where(assigned_user_id: [nil, ""])
-      elsif view.eql?("user")
-        @ideas = current_user.ideas.all
-      end
+    if params[:view].eql?('assigned')
+      @ideas = Idea.where(assigned_user_id: [current_user.id])
     else
       @ideas = Idea.all
-    end  
+    end
   end
 
   # GET /ideas/1

--- a/app/views/ideas/index.html.erb
+++ b/app/views/ideas/index.html.erb
@@ -43,7 +43,7 @@
 <%= link_to 'New Idea', new_idea_path %>
 <% if current_user.admin? %>
   <%= link_to 'Users', users_path %>
-  <%= link_to 'My Assigned Ideas', ideas_path(:view => "assigned") %>
-  <%= link_to 'Submitted Ideas', ideas_path(:view => "submitted") %>
+  <%= link_to 'My Assigned Ideas', ideas_path(view: "assigned") %>
+  <%= link_to 'Submitted Ideas', ideas_path(view: "submitted") %>
 <% end %>
 

--- a/app/views/ideas/index.html.erb
+++ b/app/views/ideas/index.html.erb
@@ -43,5 +43,7 @@
 <%= link_to 'New Idea', new_idea_path %>
 <% if current_user.admin? %>
   <%= link_to 'Users', users_path %>
+  <%= link_to 'My Assigned Ideas', ideas_path(:view => "assigned") %>
+  <%= link_to 'Submitted Ideas', ideas_path(:view => "submitted") %>
 <% end %>
 

--- a/spec/requests/ideas_spec.rb
+++ b/spec/requests/ideas_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe "Ideas", type: :request do
     describe "GET /ideas(:view => 'assigned')" do
       it "should show a list of my assigned ideas" do
         @admin_user.ideas.create!(title: "Assign idea", assigned_user_id: @admin_user.id)
-        get ideas_path(:view=>'assigned')
+        get ideas_path(view: "assigned")
         expect(response).to have_http_status(200)
         expect(response.body).to include "Assign idea"
       end

--- a/spec/requests/ideas_spec.rb
+++ b/spec/requests/ideas_spec.rb
@@ -150,5 +150,14 @@ RSpec.describe "Ideas", type: :request do
         expect(idea.assigned_user_id) == 1
       end
     end
+
+    describe "GET /ideas(:view => 'assigned')" do
+      it "should show a list of my assigned ideas" do
+        @admin_user.ideas.create!(title: "Assign idea", assigned_user_id: @admin_user.id)
+        get ideas_path(:view=>'assigned')
+        expect(response).to have_http_status(200)
+        expect(response.body).to include "Assign idea"
+      end
+    end
   end
 end

--- a/spec/system/assign_idea_spec.rb
+++ b/spec/system/assign_idea_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Assign idea", type: :system do
     @user = User.create!(email:'me@justice.gov.uk', password: 'change_me')
     @admin_user = User.create!(email:'admin@justice.gov.uk', password: 'change_me', admin: true)
     @idea =  @user.ideas.create!(
-        title: "Submit idea",
+        title: "Assign idea",
         area_of_interest: 0,
         business_area: 0,
         it_system: 0,
@@ -25,17 +25,18 @@ RSpec.describe "Assign idea", type: :system do
     end
   end
 
-  describe "admin user submitting an idea" do
+  describe "admin user assigning an idea" do
     it "should be possible to assign the idea" do
       sign_in @admin_user
       visit edit_idea_path(@idea)
       expect(page).to have_select('idea_assigned_user_id')
-      first('#idea_assigned_user_id option').select_option
-      click_button "Update Idea"
+      select 'admin@me.com', :from => 'idea_assigned_user_id'
+      click_button 'Update Idea'
       @idea.reload
       expect(@idea.assigned_user_id) == @user.id
       expect(page).to have_text('Idea was successfully updated')
+      visit ideas_path(:view => 'assigned')
+      expect(page).to have_text('Assign idea')
     end
   end
-
 end

--- a/spec/system/assign_idea_spec.rb
+++ b/spec/system/assign_idea_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe "Assign idea", type: :system do
       sign_in @admin_user
       visit edit_idea_path(@idea)
       expect(page).to have_select('idea_assigned_user_id')
-      select 'admin@me.com', :from => 'idea_assigned_user_id'
+      select 'admin@justice.gov.uk', from: 'idea_assigned_user_id'
       click_button 'Update Idea'
       @idea.reload
-      expect(@idea.assigned_user_id) == @user.id
+      expect(@idea.assigned_user_id) == @admin_user.id
       expect(page).to have_text('Idea was successfully updated')
-      visit ideas_path(:view => 'assigned')
+      visit ideas_path(view: "assigned")
       expect(page).to have_text('Assign idea')
     end
   end


### PR DESCRIPTION
What
As an admin I'd like to see a list of my assigned ideas

Ticket
https://dsdmoj.atlassian.net/browse/GI-21

Why
Admin users should have the ability to view a list of their assigned ideas. Eventually this will be a tab on their homescreen.

How
- I have added a link to the index view for admin_users "My assigned ideas". Eventually this will be a tab.
- I have added logic to the controller to filter on a paramater "view" for the index. If this equals "assigned" it will return a list of the admin user's assigned ideas. Eventually this controller logic will be extended to filter for a "submitted" ideas view, and a view to filter on a user's own "user" ideas.
- I have added associated tests for the assigned ideas view to the ideas request spec, and the assign_idea system spec.