### PR TITLE
Add email functionality to app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'jbuilder', '~> 2.8'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'devise'
+gem 'govuk_notify_rails'
 
 # Fix CVE-2018-16468 More information
 gem "loofah", ">= 2.2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,9 @@ GEM
     ffi (1.9.25)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    govuk_notify_rails (2.0.0)
+      notifications-ruby-client (>= 2.0.0)
+      rails (>= 4.1.0)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
@@ -90,6 +93,7 @@ GEM
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
     json (2.1.0)
+    jwt (2.1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -111,6 +115,8 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
+    notifications-ruby-client (2.9.0)
+      jwt (>= 1.5, < 3)
     orm_adapter (0.5.0)
     parallel (1.12.1)
     parser (2.5.3.0)
@@ -253,6 +259,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   chromedriver-helper
   devise
+  govuk_notify_rails
   jbuilder (~> 2.8)
   listen (>= 3.0.5, < 3.2)
   loofah (>= 2.2.3)

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -1,0 +1,6 @@
+class NotifyMailer < GovukNotifyRails::Mailer
+  def email_template(user, template)
+    set_template(template)
+    mail(to: user.email)
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,6 +37,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.perform_deliveries = false
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/initializers/gov_uk_notify.rb
+++ b/config/initializers/gov_uk_notify.rb
@@ -1,0 +1,2 @@
+ActionMailer::Base.add_delivery_method :govuk_notify, GovukNotifyRails::Delivery,
+                                       api_key: ENV['GOVUK_NOTIFY_API_KEY']

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe NotifyMailer, type: :mailer do
+  describe 'Email' do
+    let(:user) { double('User', name: 'Test Name', email: 'test@justice.gov.uk') }
+    let(:template) { '2561a8b1-244e-41cf-90ab-51dc27d08966' }
+    let(:mail) { described_class.email_template(user, template) }
+
+    it 'is a govuk_notify delivery' do
+      expect(mail.delivery_method).to be_a(GovukNotifyRails::Delivery)
+    end
+
+    it 'sets the recipient' do
+      expect(mail.to).to eq(['test@justice.gov.uk'])
+    end
+
+    it 'sets the body' do
+      expect(mail.body).to match("This is a GOV.UK Notify email with template #{template}")
+    end
+
+    it 'sets the template' do
+      expect(mail.govuk_notify_template).to eq(template)
+    end
+  end
+end

--- a/spec/system/email_spec.rb
+++ b/spec/system/email_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe 'Email', type: :system do
+  describe 'Send an email' do
+    it 'should send a template email' do
+      user = User.create!(email: 'test@digital.justice.gov.uk', password: 'change_me')
+      template = '2561a8b1-244e-41cf-90ab-51dc27d08966'
+      mail = NotifyMailer.email_template(user, template).deliver_now
+      expect(mail.body).to have_text("This is a GOV.UK Notify email with template")
+    end
+  end
+end


### PR DESCRIPTION
This adds Gov.uk notify email messaging.  The GOVUK_NOTIFY_API_KEY
environment variable should be set before starting the server for the
emails to work.

API Keys should be stored securely, there is a test key (doesn't send
email) and a whitelist key (sends to team members on notify).

When tests are running the perform_deliveries = false prevents
deliveries from being made externally.

The email_spec.rb is largely redundant when this setting is enabled but
I will leave it here for the moment as it is useful to test the notify
service until we have something else in the app that sends an email, by
setting the perform_deliveries to true (or commenting out)

The notify mailer is currently configured to send a simple template,
this will be updated in future PRs to add in personalisation and
integration with devise.