### PR TITLE
GI-57 Add log out link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,6 +57,9 @@
 
   <div class="govuk-width-container">
     <main class="govuk-main-wrapper " id="main-content" role="main">
+      <% if current_user %>
+        <%= link_to 'Sign out', destroy_user_session_path, method: :delete %>
+      <% end %>
       <%= yield %>
     </main>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   resources :ideas do
     post 'submit', to: 'ideas#submit'
   end
-  devise_for :users
+  devise_for :users, path: '', path_names: { sign_in: 'sign_in', sign_out: 'sign_out', sign_up: 'sign_up'}
   resources :users, only: [:index, :show] do
     post 'toggle_admin', to: 'users#toggle_admin'
   end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -29,6 +29,13 @@ RSpec.describe "Users", type: :request do
       end
     end
 
+    describe 'sign out' do
+      it 'signs the user out' do
+        delete destroy_user_session_path
+        expect(controller.current_user).to be_nil
+      end
+    end
+
   end
 
   describe "as an admin user" do

--- a/spec/system/sign_out_spec.rb
+++ b/spec/system/sign_out_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'Sign out', type: :system do
+  before do
+    @user = User.create!(email: 'me@justice.gov.uk', password: 'change_me')
+  end
+
+  describe 'as a logged in user' do
+    it 'the sign out link should sign the user out' do
+      sign_in @user
+      visit ideas_path
+      click_link 'Sign out'
+      expect(page).to have_content 'Log in'
+    end
+  end
+
+  describe 'as a logged out user' do
+    it 'should not show a log out link' do
+      visit ideas_path
+      expect(page).not_to have_link('Sign out')
+    end
+  end
+end


### PR DESCRIPTION
Log out link added to top of all pages if the current user is logged in.
This should be moved later to a better position eg nav bar when we have
one.

Also tidied up the urls for the users/sign_in etc to just /sign_in as
the user part at the start is a little untidy.