### PR TITLE
Feature/add status to ideas

### DIFF
--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -87,7 +87,7 @@ class IdeasController < ApplicationController
    # Never trust parameters from the scary internet, only allow the white list through.
     def idea_params
       if current_user.admin?
-        params.require(:idea).permit(:area_of_interest, :business_area, :it_system, :title, :idea, :benefits, :impact, :involvement, :assigned_user_id)
+        params.require(:idea).permit(:area_of_interest, :business_area, :it_system, :title, :idea, :benefits, :impact, :involvement, :assigned_user_id, :status)
       else
         params.require(:idea).permit(:area_of_interest, :business_area, :it_system, :title, :idea, :benefits, :impact, :involvement)    
       end

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -78,4 +78,13 @@ class Idea < ApplicationRecord
     :other_business_area,
     :staff_engagement
   ]
+
+  enum status: [
+    :approved,
+    :investigation,
+    :implementing,
+    :interim_benefits,
+    :benefits_realised,
+    :not_proceeding
+  ]
 end

--- a/app/views/ideas/_form.html.erb
+++ b/app/views/ideas/_form.html.erb
@@ -56,6 +56,11 @@
       <%= form.label :assigned_user_id %>
       <%= form.collection_select(:assigned_user_id, User.all.where(:admin => true), :id, :email, :prompt => true) %>
     </div>
+
+    <div class="field">
+      <%= form.label :status %>
+      <%= form.select :status, enum_to_select(Idea.statuses) %>
+    </div>
   <% end %>
 
   <div class="actions">

--- a/app/views/ideas/index.html.erb
+++ b/app/views/ideas/index.html.erb
@@ -14,6 +14,7 @@
       <th>Impact</th>
       <th>Involvement</th>
       <th>Assigned User</th>
+      <th>Status</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -30,6 +31,7 @@
         <td><%= idea.impact %></td>
         <td><%= idea.involvement %></td>
         <td><%= idea.assigned_user&.email %></td>
+        <td><%= idea.status %></td>
         <td><%= link_to 'Show', idea %></td>
         <td><%= link_to 'Edit', edit_idea_path(idea) %></td>
         <td><%= link_to 'Destroy', idea, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -48,7 +48,12 @@
 <p>
   <strong>Assigned user:</strong>
   <%= @idea.assigned_user&.email %>
- </p>
+</p>
+
+<p>
+  <strong>Status:</strong>
+  <%= @idea.status %>
+</p>
 
 <%= link_to 'Edit', edit_idea_path(@idea) %> |
 <%= link_to 'Back', ideas_path %>

--- a/db/migrate/20181120124254_add_status_to_ideas.rb
+++ b/db/migrate/20181120124254_add_status_to_ideas.rb
@@ -1,0 +1,5 @@
+class AddStatusToIdeas < ActiveRecord::Migration[5.2]
+  def change
+    add_column :ideas, :status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_05_133919) do
+ActiveRecord::Schema.define(version: 2018_11_20_124254) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 2018_11_05_133919) do
     t.integer "user_id"
     t.datetime "submission_date"
     t.integer "assigned_user_id"
+    t.integer "status"
     t.index ["assigned_user_id"], name: "index_ideas_on_assigned_user_id"
     t.index ["user_id"], name: "index_ideas_on_user_id"
   end

--- a/spec/requests/ideas_spec.rb
+++ b/spec/requests/ideas_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe "Ideas", type: :request do
       end
     end
 
+    describe "PATCH /idea" do
+      it "should not show a status field" do
+        idea = @user.ideas.create!(title: "An idea to update")
+        get edit_idea_path(idea)
+        expect(response.body).not_to include "status"
+      end
+    end
+
     describe "update an idea" do
       it "should change an existing idea" do
         idea = @user.ideas.create!(title: "An idea")
@@ -142,6 +150,14 @@ RSpec.describe "Ideas", type: :request do
       end
     end
 
+    describe "PATCH /idea" do
+      it "should show a status field" do
+        idea = @admin_user.ideas.create!(title: "An idea to update")
+        get edit_idea_path(idea)
+        expect(response.body).to include "status"
+      end
+    end
+
     describe "assign an idea" do
       it "should assign an existing idea" do
         idea = @admin_user.ideas.create!(title: "An idea")
@@ -157,6 +173,15 @@ RSpec.describe "Ideas", type: :request do
         get ideas_path(view: "assigned")
         expect(response).to have_http_status(200)
         expect(response.body).to include "Assign idea"
+      end
+    end
+
+    describe "update the status of an idea" do
+      it "should update the status of an idea" do
+        idea = @admin_user.ideas.create!(title: "An idea to update")
+        patch idea_path(idea), params: { idea: { status: 'approved'}}
+        idea.reload
+        expect(idea.status) == 'approved'
       end
     end
 

--- a/spec/system/update_status_spec.rb
+++ b/spec/system/update_status_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe "Update status", type: :system do
+
+  before do
+    @user = User.create!(email:'me@justice.gov.uk', password: 'change_me')
+    @admin_user = User.create!(email:'admin@justice.gov.uk', password: 'change_me', admin: true)
+    @idea =  @user.ideas.create!(
+        title: "Update status idea",
+        area_of_interest: 0,
+        business_area: 0,
+        it_system: 0,
+        idea: "Idea",
+        benefits: 0,
+        impact: "Impact",
+        involvement: 0
+      )   
+  end
+
+  describe "user updating an idea" do
+    it "should not be possible to update the status of the idea" do
+      sign_in @user      
+      visit edit_idea_path(@idea)
+      expect(page).not_to have_select('idea_status')
+    end
+  end
+
+  describe "admin user updating an idea" do
+    it "should be possible to update the status of the idea" do
+      sign_in @admin_user
+      visit edit_idea_path(@idea)
+      expect(page).to have_select('idea_status')
+      select 'Approved', from: 'idea_status'
+      click_button 'Update Idea'
+      @idea.reload
+      expect(@idea.status) == 1
+      expect(page).to have_text('Idea was successfully updated')
+      visit ideas_path
+      expect(page).to have_text('approved')
+    end
+  end
+end


### PR DESCRIPTION
What
As an admin I'd like to be able to update the status of an idea

Ticket
https://dsdmoj.atlassian.net/browse/GI-58

Why
Admin users should have the ability update the status of an idea

How
I have created a migration to add a status column to the ideas table
I have added an enum status to the idea model.
I have added a status field to the form view which is available only to admins.
I have added status to the index and show views.
I have added associated tests for status view to the ideas request spec, and created an update_status system spec.