### PR TITLE
Set status to awaiting approval when an idea is submitted

### DIFF
--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -83,7 +83,7 @@ class IdeasController < ApplicationController
         :benefits,
         :impact,
         :involvement,
-        :assigned_user_id, 
+        :assigned_user_id,
         :status
       )
     else

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -56,6 +56,7 @@ class IdeasController < ApplicationController
 
   def submit
     @idea.submission_date = Time.now
+    @idea.status = 0
     if @idea.save
       redirect_to @idea, notice: 'Idea was successfully submitted.'
     else
@@ -82,7 +83,8 @@ class IdeasController < ApplicationController
         :benefits,
         :impact,
         :involvement,
-        :assigned_user_id, :status
+        :assigned_user_id, 
+        :status
       )
     else
       params.require(:idea).permit(
@@ -93,7 +95,8 @@ class IdeasController < ApplicationController
         :idea,
         :benefits,
         :impact,
-        :involvement
+        :involvement,
+        :status
       )
     end
   end

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -82,6 +82,7 @@ class Idea < ApplicationRecord
   ]
 
   enum status: %i[
+    awaiting_approval
     approved
     investigation
     implementing

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -57,4 +57,6 @@
 
 <%= link_to 'Edit', edit_idea_path(@idea) %> |
 <%= link_to 'Back', ideas_path %>
-<%= button_to 'Submit idea', idea_submit_path(@idea) %>
+<% if @idea.status == nil %>
+  <%= button_to 'Submit idea', idea_submit_path(@idea) %>
+<% end %>

--- a/spec/requests/ideas_spec.rb
+++ b/spec/requests/ideas_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe 'Ideas', type: :request do
         post idea_submit_path(idea)
         idea.reload
         expect(idea.submission_date).to_not be_nil
+        expect(idea.status).to eq 'awaiting_approval'
         expect(idea.area_of_interest).to_not be_nil
         expect(idea.business_area).to_not be_nil
         expect(idea.it_system).to_not be_nil

--- a/spec/system/idea_submission_spec.rb
+++ b/spec/system/idea_submission_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'Ideas submission', type: :system do
       click_button 'Submit idea'
       idea.reload
       expect(idea.submission_date).to_not be_nil
+      expect(idea.status).to eq 'awaiting_approval'
       expect(page).to have_text('Idea was successfully submitted.')
     end
   end


### PR DESCRIPTION
What
When I submit an idea it is given the status of Awaiting Approval

Ticket
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?projectKey=GI&rapidView=250&selectedIssue=GI-61

Why

So that admin users can see newly submitted ideas

How
Added awaiting_approval to the ideas model
Added code in controller so that idea.status is updated to awaiting_approval on submission
Added a check in ideas show view so that only unsubmitted ideas can be submitted
Added request and system spec tests for changes