### PR TITLE
Add review_date and participation_level admin fields

### DIFF
--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -56,7 +56,7 @@ class IdeasController < ApplicationController
 
   def submit
     @idea.submission_date = Time.now
-    @idea.status = 0
+    @idea.status = Idea.statuses[:awaiting_approval]
     if @idea.save
       redirect_to @idea, notice: 'Idea was successfully submitted.'
     else
@@ -84,7 +84,9 @@ class IdeasController < ApplicationController
         :impact,
         :involvement,
         :assigned_user_id,
-        :status
+        :participation_level,
+        :status,
+        :review_date
       )
     else
       params.require(:idea).permit(

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -91,4 +91,9 @@ class Idea < ApplicationRecord
     benefits_realised
     not_proceeding
   ]
+
+  enum participation_level: %i[
+    assist
+    lead
+  ]
 end

--- a/app/views/ideas/_form.html.erb
+++ b/app/views/ideas/_form.html.erb
@@ -58,8 +58,18 @@
     </div>
 
     <div class="field">
+      <%= form.label :participation_level %>
+      <%= form.select :participation_level, enum_to_select(Idea.participation_levels) %>
+    </div>
+
+    <div class="field">
       <%= form.label :status %>
       <%= form.select :status, enum_to_select(Idea.statuses) %>
+    </div>
+
+    <div class="field">
+      <%= form.label :review_date %>
+      <%= form.date_select :review_date %>
     </div>
   <% end %>
 

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -51,8 +51,18 @@
 </p>
 
 <p>
+  <strong>Participation level:</strong>
+  <%= @idea.participation_level %>
+</p>
+
+<p>
   <strong>Status:</strong>
   <%= @idea.status %>
+</p>
+
+<p>
+  <strong>Review date:</strong>
+  <%= @idea.review_date %>
 </p>
 
 <%= link_to 'Edit', edit_idea_path(@idea) %> |

--- a/db/migrate/20181205085733_add_review_date_to_ideas.rb
+++ b/db/migrate/20181205085733_add_review_date_to_ideas.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReviewDateToIdeas < ActiveRecord::Migration[5.2]
+  def change
+    add_column :ideas, :review_date, :date, default: nil
+  end
+end

--- a/db/migrate/20181205095926_add_participation_level_to_ideas.rb
+++ b/db/migrate/20181205095926_add_participation_level_to_ideas.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddParticipationLevelToIdeas < ActiveRecord::Migration[5.2]
+  def change
+    add_column :ideas, :participation_level, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_23_140831) do
+ActiveRecord::Schema.define(version: 2018_12_05_095926) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "comments", force: :cascade do |t|
-    t.string "body"
+    t.string "body", null: false
     t.integer "status_at_comment_time"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -41,6 +41,8 @@ ActiveRecord::Schema.define(version: 2018_11_23_140831) do
     t.datetime "submission_date"
     t.integer "assigned_user_id"
     t.integer "status"
+    t.date "review_date"
+    t.integer "participation_level"
     t.index ["assigned_user_id"], name: "index_ideas_on_assigned_user_id"
     t.index ["user_id"], name: "index_ideas_on_user_id"
   end

--- a/spec/requests/ideas_spec.rb
+++ b/spec/requests/ideas_spec.rb
@@ -42,16 +42,12 @@ RSpec.describe 'Ideas', type: :request do
     end
 
     describe 'PATCH /idea' do
-      it 'should not show an assigned_user field' do
+      it 'should not show admin only fields' do
         get edit_idea_path(idea)
         expect(response.body).not_to include 'assigned_user_id'
-      end
-    end
-
-    describe 'PATCH /idea' do
-      it 'should not show a status field' do
-        get edit_idea_path(idea)
         expect(response.body).not_to include 'status'
+        expect(response.body).not_to include 'participation_level'
+        expect(response.body).not_to include 'review_date'
       end
     end
 
@@ -127,24 +123,24 @@ RSpec.describe 'Ideas', type: :request do
     end
 
     describe 'PATCH /idea' do
-      it 'should show an assigned_user field' do
+      it 'should show admin only fields' do
         get edit_idea_path(idea)
         expect(response.body).to include 'assigned_user_id'
-      end
-    end
-
-    describe 'PATCH /idea' do
-      it 'should show a status field' do
-        get edit_idea_path(idea)
         expect(response.body).to include 'status'
+        expect(response.body).to include 'participation_level'
+        expect(response.body).to include 'review_date'
       end
     end
 
-    describe 'assign an idea' do
-      it 'should assign an existing idea' do
-        patch idea_path(idea), params: { idea: { assigned_user_id: 1 } }
+    describe 'update admin fields' do
+      it 'should update existing idea' do
+        patch idea_path(idea), params: { idea: { assigned_user_id: 1, status: 'approved',
+                                                 participation_level: 'assist', review_date: Date.today } }
         idea.reload
-        expect(idea.assigned_user_id) == 1
+        expect(idea.assigned_user_id).to eq 1
+        expect(idea.status).to eq 'approved'
+        expect(idea.participation_level).to eq 'assist'
+        expect(idea.review_date).to eq Date.today
       end
     end
 
@@ -154,14 +150,6 @@ RSpec.describe 'Ideas', type: :request do
         get ideas_path(view: 'assigned')
         expect(response).to have_http_status(200)
         expect(response.body).to include 'Assign idea'
-      end
-    end
-
-    describe 'update the status of an idea' do
-      it 'should update the status of an idea' do
-        patch idea_path(idea), params: { idea: { status: 'approved' } }
-        idea.reload
-        expect(idea.status) == 'approved'
       end
     end
 

--- a/spec/system/assign_idea_spec.rb
+++ b/spec/system/assign_idea_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'Assign idea', type: :system do
       sign_in default_user
       visit edit_idea_path(idea)
       expect(page).not_to have_select('idea_assigned_user_id')
+      expect(page).not_to have_select('idea_participation_level')
     end
   end
 
@@ -20,10 +21,13 @@ RSpec.describe 'Assign idea', type: :system do
       sign_in admin_user
       visit edit_idea_path(idea)
       expect(page).to have_select('idea_assigned_user_id')
+      expect(page).to have_select('idea_participation_level')
       select 'admin@justice.gov.uk', from: 'idea_assigned_user_id'
+      select 'Lead', from: 'idea_participation_level'
       click_button 'Update Idea'
       idea.reload
       expect(idea.assigned_user_id).to eq(admin_user.id)
+      expect(idea.participation_level).to eq('lead')
       expect(page).to have_text('Idea was successfully updated')
       visit ideas_path(view: 'assigned')
       expect(page).to have_text('New idea1')


### PR DESCRIPTION
What
As an admin I'd like to be able to edit and add information to an idea so I can start actioning it

Ticket
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?projectKey=GI&rapidView=250&selectedIssue=GI-22

Why
To introduce extra required admin only fields (Participation level and Review date)

How
Added participation_level to the ideas model
Added review_date to the ideas model
Made associated view and controller changes
Added request and system spec tests for changes