### PR TITLE
GI-56 Integrate email with devise for confirmation

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -58,7 +58,6 @@ class RegistrationsController < Devise::RegistrationsController
   # The path used after sign up for inactive accounts.
   def after_inactive_sign_up_path_for(resource)
     super(resource)
-    flash[:alert] = 'You have successfully signed up, please click the confirmation link sent to your email'
     new_user_session_path
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  # super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  def after_inactive_sign_up_path_for(resource)
+    super(resource)
+    flash[:alert] = 'You have successfully signed up, please click the confirmation link sent to your email'
+    new_user_session_path
+  end
+end

--- a/app/mailers/devise_custom_mailer.rb
+++ b/app/mailers/devise_custom_mailer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class DeviseCustomMailer < Devise::Mailer
+  helper :application # gives access to all helpers defined within `application_helper`.
+  include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
+  # default template_path: 'devise/mailer' # to make sure that your mailer uses the devise views
+
+  def confirmation_instructions(record, token, _opts = {})
+    url = confirmation_url(record, confirmation_token: token)
+    set_template('04e87e44-5fcf-4cc2-b7b8-776beb6da4e5')
+    set_personalisation(
+      token_url: url
+    )
+    mail(to: record.email)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,6 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, :confirmable
   validates :email, presence: true, email: true
 end

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Comments</h1>
 
 <%= render 'comment_list', comments: @comments %>

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>
   <strong>Comment:<strong>
   <br/>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Sign in to Great Ideas</h1>
+    <%= devise_error_messages! %>
+    <%= flash.alert %>
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
       <div class="govuk-form-group">
         <%= f.label :email, class: "govuk-label" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,7 +2,6 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Sign in to Great Ideas</h1>
     <%= devise_error_messages! %>
-    <%= flash.alert %>
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
       <div class="govuk-form-group">
         <%= f.label :email, class: "govuk-label" %>

--- a/app/views/ideas/index.html.erb
+++ b/app/views/ideas/index.html.erb
@@ -1,6 +1,3 @@
-<p class="notice" id="notice"><%= notice %></p>
-
-  
   <h1 class="govuk-heading-l">Home</h1>
 
 

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>
   <strong>Area of interest:</strong>
   <%= @idea.area_of_interest %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -83,6 +83,9 @@
 
   <div class="govuk-width-container">
     <main class="govuk-main-wrapper " id="main-content" role="main">
+      <% flash.each do |name, msg| -%>
+        <%= content_tag :div, msg, class: name %>
+      <% end -%>
       <%= yield %>
     </main> 
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Users</h1>
 
 <table>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>
   <strong>Email:</strong>
   <%= @user.email %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,4 +46,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,13 +18,13 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'laa-great-ideas@digital.justice.gov.uk'
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'DeviseCustomMailer'
 
   # Configure the parent class responsible to send e-mails.
-  # config.parent_mailer = 'ActionMailer::Base'
+  config.parent_mailer = 'GovukNotifyRails::Mailer'
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,10 @@ Rails.application.routes.draw do
     post 'submit', to: 'ideas#submit'
     resources :comments
   end
-  devise_for :users, path: '', path_names: { sign_in: 'sign_in', sign_out: 'sign_out', sign_up: 'sign_up' }
+  devise_for :users,
+             controllers: { registrations: 'registrations' },
+             path: '',
+             path_names: { sign_in: 'sign_in', sign_out: 'sign_out', sign_up: 'sign_up' }
   resources :users, only: %i[index show] do
     post 'toggle_admin', to: 'users#toggle_admin'
   end

--- a/spec/controllers/ideas_controller_spec.rb
+++ b/spec/controllers/ideas_controller_spec.rb
@@ -26,9 +26,7 @@ require 'rails_helper'
 # `rails-controller-testing` gem.
 
 RSpec.describe IdeasController, type: :controller do
-  let(:default_user) do
-    User.create!(email: 'me@justice.gov.uk', password: 'change_me')
-  end
+  let(:default_user) { create :user }
   # This should return the minimal set of attributes required to create a valid
   # Idea. As you add validations to Idea, be sure to
   # adjust the attributes here as well.

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     email { 'me@justice.gov.uk' }
     password { 'change_me' }
     admin { false }
+    confirmed_at { Time.now }
 
     factory :admin do
       email { 'admin@justice.gov.uk' }

--- a/spec/system/sign_up_spec.rb
+++ b/spec/system/sign_up_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Sign up', type: :system do
       fill_in 'user_password', with: 'change_me'
       fill_in 'user_password_confirmation', with: 'change_me'
       click_button 'Sign up'
-      expect(page).to have_content 'Welcome! You have signed up successfully.'
+      expect(page).to have_content 'You have successfully signed up, please click the confirmation link sent to your email'
     end
 
     it 'should allow digital.justice.gov.uk email addresses' do
@@ -19,7 +19,7 @@ RSpec.describe 'Sign up', type: :system do
       fill_in 'user_password', with: 'change_me'
       fill_in 'user_password_confirmation', with: 'change_me'
       click_button 'Sign up'
-      expect(page).to have_content 'Welcome! You have signed up successfully.'
+      expect(page).to have_content 'You have successfully signed up, please click the confirmation link sent to your email'
     end
 
     it 'should not allow non justice.gov.uk email addresses' do

--- a/spec/system/sign_up_spec.rb
+++ b/spec/system/sign_up_spec.rb
@@ -9,8 +9,9 @@ RSpec.describe 'Sign up', type: :system do
       fill_in 'user_email', with: 'user@justice.gov.uk'
       fill_in 'user_password', with: 'change_me'
       fill_in 'user_password_confirmation', with: 'change_me'
+      expect_any_instance_of(DeviseCustomMailer).to receive(:confirmation_instructions).and_call_original
       click_button 'Sign up'
-      expect(page).to have_content 'You have successfully signed up, please click the confirmation link sent to your email'
+      expect(page).to have_content 'A message with a confirmation link has been sent to your email address.'
     end
 
     it 'should allow digital.justice.gov.uk email addresses' do
@@ -19,7 +20,7 @@ RSpec.describe 'Sign up', type: :system do
       fill_in 'user_password', with: 'change_me'
       fill_in 'user_password_confirmation', with: 'change_me'
       click_button 'Sign up'
-      expect(page).to have_content 'You have successfully signed up, please click the confirmation link sent to your email'
+      expect(page).to have_content 'A message with a confirmation link has been sent to your email address.'
     end
 
     it 'should not allow non justice.gov.uk email addresses' do


### PR DESCRIPTION
This change integrates the notify mailer with devise by creating a
custom mailer. The flash message was not being passed to the page after
signing up, as this was redirecting through to the home page, then
redirecting back to the sign in page.  To fix this the registrations
controller in devise is overridden, and a new flash message is passed
in.

User model updated to be confirmable (part of devise confirmations)
Devise mailer config changed
Mail url default options set for dev, not having this set was causing tests to fail.
User factory updated so that created users are already confirmed
Routes updated with new controller
