### PR TITLE
Fix seed data to include user confirmation

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,20 +5,23 @@ require 'faker'
 User.create!(
   email: 'admin@justice.gov.uk',
   password: 'change_me',
-  admin: true
+  admin: true,
+  confirmed_at: Time.now
 )
 
 User.create!(
   email: 'user@justice.gov.uk',
   password: 'change_me',
-  admin: false
+  admin: false,
+  confirmed_at: Time.now
 )
 
 10.times do
   User.create!(
     email: "#{Faker::Name.first_name}@justice.gov.uk",
     password: 'change_me',
-    admin: false
+    admin: false,
+    confirmed_at: Time.now
   )
 end
 
@@ -26,7 +29,8 @@ end
   User.create!(
     email: "#{Faker::Name.first_name}@justice.gov.uk",
     password: 'change_me',
-    admin: true
+    admin: true,
+    confirmed_at: Time.now
   )
 end
 


### PR DESCRIPTION
After updating authentication with devise to require user confirmation,
the seed data was not updated, so all seed users are currently unconfirmed.

This will fix this.