### PR TITLE
Feature/assigned idea email

### DIFF
--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -43,7 +43,9 @@ class IdeasController < ApplicationController
 
   # PATCH/PUT /ideas/1
   def update
+    old_assigned_user_id = @idea.assigned_user_id
     if @idea.update(idea_params)
+      send_assigned_user_email(old_assigned_user_id)
       redirect_to @idea, notice: 'Idea was successfully updated.'
     else
       render :edit
@@ -102,6 +104,13 @@ class IdeasController < ApplicationController
         :involvement,
         :status
       )
+    end
+  end
+
+  def send_assigned_user_email(old_assigned_user_id)
+    if @idea.assigned_user_id != old_assigned_user_id
+      template = '8c344764-890c-491c-9301-27cbd92a1c26'
+      mail = NotifyMailer.idea_email_template(@idea.assigned_user, @idea, template).deliver_now
     end
   end
 end

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -45,7 +45,7 @@ class IdeasController < ApplicationController
   def update
     old_assigned_user_id = @idea.assigned_user_id
     if @idea.update(idea_params)
-      send_assigned_user_email(old_assigned_user_id)
+      send_assigned_user_email if @idea.assigned_user_id != old_assigned_user_id
       redirect_to @idea, notice: 'Idea was successfully updated.'
     else
       render :edit
@@ -107,10 +107,8 @@ class IdeasController < ApplicationController
     end
   end
 
-  def send_assigned_user_email(old_assigned_user_id)
-    if @idea.assigned_user_id != old_assigned_user_id
-      template = '8c344764-890c-491c-9301-27cbd92a1c26'
-      mail = NotifyMailer.idea_email_template(@idea.assigned_user, @idea, template).deliver_now
-    end
+  def send_assigned_user_email
+    template = '8c344764-890c-491c-9301-27cbd92a1c26'
+    NotifyMailer.idea_email_template(@idea.assigned_user, @idea, template).deliver_now
   end
 end

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -5,4 +5,13 @@ class NotifyMailer < GovukNotifyRails::Mailer
     set_template(template)
     mail(to: user.email)
   end
+
+  def idea_email_template(user, idea, template)
+    set_template(template)
+    puts idea.title
+    set_personalisation(
+      title: idea.title
+    )
+    mail(to: user.email)
+  end
 end

--- a/spec/requests/ideas_spec.rb
+++ b/spec/requests/ideas_spec.rb
@@ -134,10 +134,10 @@ RSpec.describe 'Ideas', type: :request do
 
     describe 'update admin fields' do
       it 'should update existing idea' do
-        patch idea_path(idea), params: { idea: { assigned_user_id: 1, status: 'approved',
+        patch idea_path(idea), params: { idea: { assigned_user_id: admin_user.id, status: 'approved',
                                                  participation_level: 'assist', review_date: Date.today } }
         idea.reload
-        expect(idea.assigned_user_id).to eq 1
+        expect(idea.assigned_user_id).to eq admin_user.id
         expect(idea.status).to eq 'approved'
         expect(idea.participation_level).to eq 'assist'
         expect(idea.review_date).to eq Date.today

--- a/spec/system/email_spec.rb
+++ b/spec/system/email_spec.rb
@@ -11,4 +11,17 @@ RSpec.describe 'Email', type: :system do
       expect(mail.body).to have_text('This is a GOV.UK Notify email with template')
     end
   end
+
+  describe 'Send an assigned idea email' do
+    let(:admin_user) { build :admin }
+    let(:idea) {build :idea }
+    it 'should send an assigned idea email' do
+      idea.assigned_user_id = admin_user.id
+      template = '8c344764-890c-491c-9301-27cbd92a1c26'
+      mail = NotifyMailer.idea_email_template(admin_user, idea, template).deliver_now
+      expect(mail.body).to have_text('This is a GOV.UK Notify email with template')
+      expect(mail.body).to have_text(template)
+      expect(mail.body).to have_text(idea.title)
+    end
+  end
 end

--- a/spec/system/email_spec.rb
+++ b/spec/system/email_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Email', type: :system do
 
   describe 'Send an assigned idea email' do
     let(:admin_user) { build :admin }
-    let(:idea) {build :idea }
+    let(:idea) { build :idea }
     it 'should send an assigned idea email' do
       idea.assigned_user_id = admin_user.id
       template = '8c344764-890c-491c-9301-27cbd92a1c26'


### PR DESCRIPTION
What
As an admin if an idea is assigned to me I receive an email notification

Ticket
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?projectKey=GI&rapidView=250&selectedIssue=GI-48

Why
As an admin if an idea is assigned to me I receive an email notification

How
Amended ideas_controller to send an email if the assigned_user field is updated
Amended notify_mailer to include an idea_email_template
Added a template Assigned Idea Template in the gov.uk notify console
Added a system test spec for the assigned idea email