### PR TITLE
GI-75 Only Approved ideas can have comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -13,7 +13,11 @@ class CommentsController < ApplicationController
   def show; end
 
   def new
-    @comment = @idea.comments.build
+    if @idea.approved?
+      @comment = @idea.comments.build
+    else
+      redirect_to @idea, notice: 'Comments can only be added to approved ideas.'
+    end
   end
 
   def edit; end
@@ -32,12 +36,16 @@ class CommentsController < ApplicationController
   end
 
   def create
-    @comment = @idea.comments.build(comment_params)
-    @comment.user = current_user
-    if @comment.save
-      redirect_to idea_comment_path(@comment.idea, @comment), notice: 'Comment created'
+    if @idea.approved?
+      @comment = @idea.comments.build(comment_params)
+      @comment.user = current_user
+      if @comment.save
+        redirect_to idea_comment_path(@comment.idea, @comment), notice: 'Comment created'
+      else
+        render :new
+      end
     else
-      render :new
+      redirect_to @idea, notice: 'Comments can only be added to approved ideas.'
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -13,11 +13,10 @@ class CommentsController < ApplicationController
   def show; end
 
   def new
-    if @idea.approved?
-      @comment = @idea.comments.build
-    else
-      redirect_to @idea, notice: 'Comments can only be added to approved ideas.'
-    end
+    redirect_to @idea, notice: 'Comments can only be added to approved ideas.' unless @idea.approved_by_admin?
+    return if performed?
+
+    @comment = @idea.comments.build
   end
 
   def edit; end
@@ -36,17 +35,15 @@ class CommentsController < ApplicationController
   end
 
   def create
-    if @idea.approved?
-      @comment = @idea.comments.build(comment_params)
-      @comment.user = current_user
-      if @comment.save
-        redirect_to idea_comment_path(@comment.idea, @comment), notice: 'Comment created'
-      else
-        render :new
-      end
-    else
-      redirect_to @idea, notice: 'Comments can only be added to approved ideas.'
-    end
+    redirect_to @idea, notice: 'Comments can only be added to approved ideas.' unless @idea.approved_by_admin?
+    return if performed?
+
+    @comment = @idea.comments.build(comment_params)
+    @comment.user = current_user
+    render :new unless @comment.save
+    return if performed?
+
+    redirect_to idea_comment_path(@comment.idea, @comment), notice: 'Comment created'
   end
 
   def set_comment

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -17,6 +17,12 @@ class Idea < ApplicationRecord
     submission_date.present?
   end
 
+  def approved?
+    return false if status == 'awaiting_approval' || status.nil?
+
+    true
+  end
+
   enum benefits: %i[
     better_decision_making
     improved_reputation

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -17,7 +17,7 @@ class Idea < ApplicationRecord
     submission_date.present?
   end
 
-  def approved?
+  def approved_by_admin?
     return false if status == 'awaiting_approval' || status.nil?
 
     true

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -68,8 +68,10 @@
 <% if @idea.status == nil %>
   <%= button_to 'Submit idea', idea_submit_path(@idea) %>
 <% end %>
-<%= link_to 'Add Comment', new_idea_comment_path(@idea) %>
+<% if @idea.approved? %>
+  <%= link_to 'Add Comment', new_idea_comment_path(@idea) %>
 
-<h2>Comments</h2>
+  <h2>Comments</h2>
 
-<%= render 'comments/comment_list', comments: @idea.comments %>
+  <%= render 'comments/comment_list', comments: @idea.comments %>
+<% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,6 @@
 
 require 'faker'
 
-puts 'Creating admin user admin@justice.gov.uk/change_me'
 User.create!(
   email: 'admin@justice.gov.uk',
   password: 'change_me',
@@ -10,7 +9,6 @@ User.create!(
   confirmed_at: Time.now
 )
 
-puts 'Creating normal user user@justice.gov.uk/change_me'
 User.create!(
   email: 'user@justice.gov.uk',
   password: 'change_me',
@@ -18,7 +16,6 @@ User.create!(
   confirmed_at: Time.now
 )
 
-puts 'Creating 10 normal users'
 10.times do
   User.create!(
     email: "#{Faker::Name.first_name}@justice.gov.uk",
@@ -28,7 +25,6 @@ puts 'Creating 10 normal users'
   )
 end
 
-puts 'Creating 10 admin users'
 10.times do
   User.create!(
     email: "#{Faker::Name.first_name}@justice.gov.uk",
@@ -38,7 +34,6 @@ puts 'Creating 10 admin users'
   )
 end
 
-puts 'Creating 20 submitted ideas'
 20.times do
   user = User.offset(rand(User.count)).first
   user.ideas.create!(
@@ -55,7 +50,6 @@ puts 'Creating 20 submitted ideas'
   )
 end
 
-puts 'Creating 10 unsubmitted ideas'
 10.times do
   user = User.offset(rand(User.count)).first
   user.ideas.create!(
@@ -70,7 +64,6 @@ puts 'Creating 10 unsubmitted ideas'
   )
 end
 
-puts 'Creating comment for each approved idea'
 Idea.find_each do |idea|
   if idea.approved?
     user = User.offset(rand(User.count)).first

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,6 +2,7 @@
 
 require 'faker'
 
+puts 'Creating admin user admin@justice.gov.uk/change_me'
 User.create!(
   email: 'admin@justice.gov.uk',
   password: 'change_me',
@@ -9,6 +10,7 @@ User.create!(
   confirmed_at: Time.now
 )
 
+puts 'Creating normal user user@justice.gov.uk/change_me'
 User.create!(
   email: 'user@justice.gov.uk',
   password: 'change_me',
@@ -16,6 +18,7 @@ User.create!(
   confirmed_at: Time.now
 )
 
+puts 'Creating 10 normal users'
 10.times do
   User.create!(
     email: "#{Faker::Name.first_name}@justice.gov.uk",
@@ -25,6 +28,7 @@ User.create!(
   )
 end
 
+puts 'Creating 10 admin users'
 10.times do
   User.create!(
     email: "#{Faker::Name.first_name}@justice.gov.uk",
@@ -34,6 +38,7 @@ end
   )
 end
 
+puts 'Creating 20 submitted ideas'
 20.times do
   user = User.offset(rand(User.count)).first
   user.ideas.create!(
@@ -45,11 +50,13 @@ end
     idea: Faker::Simpsons.quote,
     benefits: Idea.benefits.key(rand(Idea.benefits.count)),
     impact: 'Impact',
-    involvement: Idea.involvements.key(rand(Idea.involvements.count))
+    involvement: Idea.involvements.key(rand(Idea.involvements.count)),
+    status: Idea.statuses.key(rand(Idea.statuses.count))
   )
 end
 
-20.times do
+puts 'Creating 10 unsubmitted ideas'
+10.times do
   user = User.offset(rand(User.count)).first
   user.ideas.create!(
     title: Faker::Book.title,
@@ -63,11 +70,13 @@ end
   )
 end
 
-100.times do
-  idea = Idea.offset(rand(Idea.count)).first
-  user = User.offset(rand(User.count)).first
-  idea.comments.create!(
-    body: Faker::ChuckNorris.fact,
-    user: user
-  )
+puts 'Creating comment for each approved idea'
+Idea.find_each do |idea|
+  if idea.approved?
+    user = User.offset(rand(User.count)).first
+    idea.comments.create!(
+      body: Faker::ChuckNorris.fact,
+      user: user
+    )
+  end
 end

--- a/spec/factories/ideas.rb
+++ b/spec/factories/ideas.rb
@@ -16,6 +16,10 @@ FactoryBot.define do
 
       factory :submitted_idea do
         submission_date { Time.now }
+
+        factory :approved_idea do
+          status { Idea.statuses[:approved] }
+        end
       end
     end
   end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Comments', type: :request do
   let(:default_user) { build :user }
   let(:admin_user) { build :admin }
   let(:idea) { create :idea }
+  let(:approved_idea) { create :approved_idea }
   let(:comment) { create :comment }
 
   context 'As a logged in user' do
@@ -23,18 +24,37 @@ RSpec.describe 'Comments', type: :request do
       end
     end
 
-    describe 'POST /comments' do
-      it 'creates a new comment' do
-        expect do
-          post idea_comments_path(idea), params: { comment: { body: 'Test comment' } }
-        end.to change(Comment, :count).by(1)
+    context 'with an approved idea' do
+      describe 'POST /comments' do
+        it 'creates a new comment' do
+          expect do
+            post idea_comments_path(approved_idea), params: { comment: { body: 'Test comment' } }
+          end.to change(Comment, :count).by(1)
+        end
+      end
+
+      describe 'GET /comments/new' do
+        it 'returns the new comment page' do
+          get new_idea_comment_path(approved_idea)
+          expect(response.body).to include('New Comment')
+        end
       end
     end
 
-    describe 'GET /comments/new' do
-      it 'returns the new comment page' do
-        get new_idea_comment_path(idea)
-        expect(response.body).to include('New Comment')
+    context 'with an unapproved idea' do
+      describe 'POST /comments' do
+        it 'does not create a new comment' do
+          expect do
+            post idea_comments_path(idea), params: { comment: { body: 'Test comment' } }
+          end.to change(Comment, :count).by(0)
+        end
+      end
+
+      describe 'GET /comments/new' do
+        it 'redirects to idea' do
+          get new_idea_comment_path(idea)
+          expect(response).to redirect_to(idea)
+        end
       end
     end
 

--- a/spec/system/add_comment_spec.rb
+++ b/spec/system/add_comment_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Add a comment', type: :system do
   let(:default_user) { create :user }
   let(:idea) { create :idea }
+  let(:approved_idea) { create :approved_idea }
   let(:comment) { create :comment }
 
   context 'a logged in user' do
@@ -12,28 +13,39 @@ RSpec.describe 'Add a comment', type: :system do
       sign_in default_user
     end
 
-    describe 'on the idea show page' do
-      it 'can click an add comment button' do
-        visit idea_path(idea)
-        click_on 'Add Comment'
-        expect(page).to have_text('New Comment')
+    context 'with an approved idea' do
+      describe 'on the idea show page' do
+        it 'can click an add comment button' do
+          visit idea_path(approved_idea)
+          click_on 'Add Comment'
+          expect(page).to have_text('New Comment')
+        end
+      end
+
+      describe 'creating a comment' do
+        it 'can create and save a comment' do
+          visit new_idea_comment_path(approved_idea)
+          expect(page).to have_text('New Comment')
+          fill_in('comment_body', with: 'Test comment')
+          click_on 'Create Comment'
+          expect(page).to have_text('Test comment')
+        end
+
+        it 'does not create a comment when blank' do
+          visit new_idea_comment_path(approved_idea)
+          expect(page).to have_text('New Comment')
+          click_on 'Create Comment'
+          expect(page).to have_text('prohibited this comment from being saved')
+        end
       end
     end
 
-    describe 'creating a comment' do
-      it 'can create and save a comment' do
-        visit new_idea_comment_path(idea)
-        expect(page).to have_text('New Comment')
-        fill_in('comment_body', with: 'Test comment')
-        click_on 'Create Comment'
-        expect(page).to have_text('Test comment')
-      end
-
-      it 'does not create a comment when blank' do
-        visit new_idea_comment_path(idea)
-        expect(page).to have_text('New Comment')
-        click_on 'Create Comment'
-        expect(page).to have_text('prohibited this comment from being saved')
+    context 'with an unapproved idea' do
+      describe 'on the idea show page' do
+        it 'does not show the comment button' do
+          visit idea_path(idea)
+          expect(page).to_not have_selector(:link_or_button, 'Add Comment')
+        end
       end
     end
 
@@ -57,9 +69,9 @@ RSpec.describe 'Add a comment', type: :system do
 
     describe 'viewing comments' do
       it 'shows comments under the idea' do
-        idea.comments.create!(body: 'Comment 1', user: default_user)
-        idea.comments.create!(body: 'Comment 2', user: default_user)
-        visit idea_path(idea)
+        approved_idea.comments.create!(body: 'Comment 1', user: default_user)
+        approved_idea.comments.create!(body: 'Comment 2', user: default_user)
+        visit idea_path(approved_idea)
         expect(page).to have_text('Comment 1')
         expect(page).to have_text('Comment 2')
       end

--- a/spec/system/add_comment_spec.rb
+++ b/spec/system/add_comment_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe 'Add a comment', type: :system do
 
     describe 'viewing comments' do
       it 'shows comments under the idea' do
-        approved_idea.comments.create!(body: 'Comment 1', user: default_user)
-        approved_idea.comments.create!(body: 'Comment 2', user: default_user)
+        create :comment, idea: approved_idea, body: 'Comment 1', user: default_user
+        create :comment, idea: approved_idea, body: 'Comment 2', user: default_user
         visit idea_path(approved_idea)
         expect(page).to have_text('Comment 1')
         expect(page).to have_text('Comment 2')


### PR DESCRIPTION
We do not want comments to be added to an idea until the idea has been approved.
From this point onwards they are publicly viewable and can be commented on.