### PR TITLE
GI-70 add default status of draft for ideas

### DIFF
--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -89,16 +89,16 @@ class Idea < ApplicationRecord
     staff_engagement
   ]
 
-  enum status: %i[
-    awaiting_approval
-    approved
-    investigation
-    implementing
-    interim_benefits
-    benefits_realised
-    not_proceeding
-    draft
-  ]
+  enum status: {
+    draft: 0,
+    awaiting_approval: 1,
+    approved: 2,
+    investigation: 3,
+    implementing: 4,
+    interim_benefits: 5,
+    benefits_realised: 6,
+    not_proceeding: 7
+  }
 
   enum participation_level: %i[
     assist

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -19,7 +19,7 @@ class Idea < ApplicationRecord
   end
 
   def approved_by_admin?
-    return false if status == 'awaiting_approval' || status.nil?
+    return false if status == 'awaiting_approval' || status == 'draft'
 
     true
   end
@@ -97,6 +97,7 @@ class Idea < ApplicationRecord
     interim_benefits
     benefits_realised
     not_proceeding
+    draft
   ]
 
   enum participation_level: %i[

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -19,7 +19,7 @@ class Idea < ApplicationRecord
   end
 
   def approved_by_admin?
-    return false if status == 'awaiting_approval' || status == 'draft'
+    return false if awaiting_approval? || draft?
 
     true
   end

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -65,7 +65,7 @@
 
 <%= link_to 'Edit', edit_idea_path(@idea) %> |
 <%= link_to 'Back', ideas_path %>
-<% if @idea.status == 'draft' %>
+<% if @idea.draft? %>
   <%= button_to 'Submit idea', idea_submit_path(@idea) %>
 <% end %>
 <% if @idea.approved? %>

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -65,7 +65,7 @@
 
 <%= link_to 'Edit', edit_idea_path(@idea) %> |
 <%= link_to 'Back', ideas_path %>
-<% if @idea.status == nil %>
+<% if @idea.status == 'draft' %>
   <%= button_to 'Submit idea', idea_submit_path(@idea) %>
 <% end %>
 <% if @idea.approved? %>

--- a/db/migrate/20190114094201_add_default_status_to_ideas.rb
+++ b/db/migrate/20190114094201_add_default_status_to_ideas.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDefaultStatusToIdeas < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :ideas, :status, Idea.statuses[:draft]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_05_095926) do
+ActiveRecord::Schema.define(version: 2019_01_14_094201) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 2018_12_05_095926) do
     t.integer "user_id"
     t.datetime "submission_date"
     t.integer "assigned_user_id"
-    t.integer "status"
+    t.integer "status", default: 7
     t.date "review_date"
     t.integer "participation_level"
     t.index ["assigned_user_id"], name: "index_ideas_on_assigned_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 2019_01_14_094201) do
     t.integer "user_id"
     t.datetime "submission_date"
     t.integer "assigned_user_id"
-    t.integer "status", default: 7
+    t.integer "status", default: Idea.statuses[:draft]
     t.date "review_date"
     t.integer "participation_level"
     t.index ["assigned_user_id"], name: "index_ideas_on_assigned_user_id"

--- a/spec/requests/ideas_spec.rb
+++ b/spec/requests/ideas_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe 'Ideas', type: :request do
         end.to change(Idea, :count).by(1)
 
         expect(response).to have_http_status(302)
+        expect(idea.status).to eq 'draft'
       end
     end
 

--- a/spec/requests/ideas_spec.rb
+++ b/spec/requests/ideas_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Ideas', type: :request do
         end.to change(Idea, :count).by(1)
 
         expect(response).to have_http_status(302)
-        expect(idea.status).to eq 'draft'
+        expect(idea.draft?).to be true
       end
     end
 


### PR DESCRIPTION
We want to know which ideas have not been approved (ie and admin has
approved them) we have an awaiting_approval status for ideas which have
been submitted but there was no status for initially created ideas.  By
giving new ideas a draft default status, it is much clearer.