### PR TITLE
Update Docker Ruby version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.1
+FROM ruby:2.6.0
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
   && apt-get update -qq \
   && apt-get install -y build-essential libpq-dev nodejs npm

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ docker-compose up
 ```
 In new terminal window:
 
-`docker-compose run app rake db:reset`
+`docker-compose run app bundle exec rake db:reset`
 
 ## Contributing
 


### PR DESCRIPTION
This was missed when updating the ruby version, the docker build now
uses ruby-2.6.0 image.  Updated the readme to use bundle exec for
running rake command in the docker container.