### PR TITLE
added mailto to feedback href

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -89,7 +89,7 @@
         </strong>
         <span class="govuk-phase-banner__text">
         This is a new service – your
-        <a class="govuk-link" href="#">feedback</a> will help us to improve it.
+        <a class="govuk-link" href="mailto:laa-great-ideas@digital.justice.gov.uk?subject=Great Ideas Feedback">feedback</a> will help us to improve it.
         </span>
       </p>
     </div>


### PR DESCRIPTION
I’ve added a mailto to the feedback link on the phase banner. I set it to send emails to the newly created laa-great-ideas@digital.justice.gov.uk.
We can change it to the actual email address used by the business before we host.