### PR TITLE
GI-79 Only admins can comment on not_proceeding

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class CommentsController < ApplicationController
+  include CommentsHelper
   before_action :authenticate_user!
   before_action :set_comment, only: %i[show edit update destroy]
   before_action :set_idea, only: %i[new create show edit update destroy]
@@ -13,7 +14,7 @@ class CommentsController < ApplicationController
   def show; end
 
   def new
-    redirect_to @idea, notice: 'Comments can only be added to approved ideas.' unless @idea.approved_by_admin?
+    redirect_to @idea, notice: 'You cannot create a comment on this idea' unless user_can_comment?(@idea, current_user)
     return if performed?
 
     @comment = @idea.comments.build
@@ -35,7 +36,7 @@ class CommentsController < ApplicationController
   end
 
   def create
-    redirect_to @idea, notice: 'Comments can only be added to approved ideas.' unless @idea.approved_by_admin?
+    redirect_to @idea, notice: 'You cannot create a comment on this idea' unless user_can_comment?(@idea, current_user)
     return if performed?
 
     @comment = @idea.comments.build(comment_params)

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module CommentsHelper
+  def user_can_comment?(idea, user)
+    return idea.approved_by_admin? if user.admin
+    return idea.approved_by_admin? && !idea.not_proceeding? unless user.admin
+  end
+end

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', comment: @comment %>
 
-<%= link_to 'Back', idea_comments_path(@comment.idea) %>
+<%= link_to 'Back', idea_path(@comment.idea) %>

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -59,17 +59,20 @@
   <%= button_to 'Submit idea', idea_submit_path(@idea), class: "govuk-button" %>
 <% end %>
   <p class="govuk-body"></p>
+
 <% if @idea.approved_by_admin? %>
   <p>
     <strong>Votes</strong>
     <%= @idea.votes.count %>
   </p>
-  
   <% if @idea.user_voted?(current_user) %>
     <%= button_to 'Remove Vote', idea_vote_path(@idea, @vote.id), method: :delete %>
   <% else %>
     <%= button_to 'Vote', idea_votes_path(@idea) %>
   <% end %>
+<% end %>
+
+<% if user_can_comment?(@idea, current_user) %>
   <%= link_to 'Add Comment', new_idea_comment_path(@idea), class: "govuk-button" %>
   <h3 class="govuk-heading-m">Comments</h3>
   <p class="govuk-body"></p>


### PR DESCRIPTION
We want only admins to be able to comment on not proceeding ideas.
Refactored the .approved_by_admin? logic to a helper class, as it is
starting to get complex.  We can also use this helper class to introduce
further methods such as user_can_edit_comment for future stories.