### PR TITLE
Ensure email addresses in seeds are unique

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,7 +18,7 @@ User.create!(
 
 10.times do
   User.create!(
-    email: "#{Faker::Name.first_name}@justice.gov.uk",
+    email: "#{Faker::Name.first_name}.#{Faker::Name.unique.last_name}@justice.gov.uk",
     password: 'change_me',
     admin: false,
     confirmed_at: Time.now


### PR DESCRIPTION
Faker was occasionally providing the same name and the unique email
validation was causing the seed load to fail. This prevents the email
from being a duplicate and also gives a more realistic email address
with firstname.lastname