### PR TITLE
GI-81 Fix comments showing user and idea ID

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -8,7 +8,7 @@ class CommentsController < ApplicationController
 
   # GET /comments
   def index
-    @comments = Comment.where('idea_id = ?', params[:idea_id])
+    @comments = Comment.includes(:user).where('idea_id = ?', params[:idea_id])
   end
 
   def show; end
@@ -48,7 +48,7 @@ class CommentsController < ApplicationController
   end
 
   def set_comment
-    @comment = Comment.find(params[:id])
+    @comment = Comment.includes(:user).find(params[:id])
   end
 
   def set_idea

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -21,7 +21,7 @@ class IdeasController < ApplicationController
   # GET /ideas/1
   # GET /ideas/1.json
   def show
-    @idea = Idea.includes(:comments).find(params[:id])
+    @idea = Idea.includes(:comments).includes(:user).find(params[:id])
   end
 
   # GET /ideas/new

--- a/app/views/comments/_comment_list.html.erb
+++ b/app/views/comments/_comment_list.html.erb
@@ -3,7 +3,6 @@
     <tr class="govuk-table__row">
       <th class="govuk-table__header">Comment</th>
       <th class="govuk-table__header">Author</th>
-      <th class="govuk-table__header">Idea</th>
       <th class="govuk-table__header">Status at time of comment</th>
       <th class="govuk-table__header">Created at</th>
      <th  class="govuk-table__header" colspan="3"></th>
@@ -13,8 +12,7 @@
     <% comments.each do |comment| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= comment.body %></td>
-        <td class="govuk-table__cell"><%= comment.user_id %></td>
-        <td class="govuk-table__cell"><%= comment.idea_id %></td>
+        <td class="govuk-table__cell"><%= comment.user.email %></td>
         <td class="govuk-table__cell"><%= t(comment.status_at_comment_time) %></td>
         <td class="govuk-table__cell"><%= comment.created_at %></td>
         <td class="govuk-table__cell"><%= link_to 'Show', idea_comment_path(comment.idea, comment) %></td>

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -7,7 +7,7 @@
   </tr>
   <tr class="govuk-table__row">
     <th class="govuk-table__header" scope="row">User ID:</th>
-    <td class="govuk-table__cell"><%= @comment.user_id%></td>
+    <td class="govuk-table__cell"><%= @comment.user.email%></td>
   </tr>
   <tr class="govuk-table__row">
     <th class="govuk-table__header" scope="row">Status at comment time:</th>

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -3,20 +3,20 @@
 require 'rails_helper'
 
 RSpec.describe 'Comments', type: :request do
-  let(:default_user) { build :user }
-  let(:admin_user) { build :admin }
+  let(:default_user) { create :user }
+  let(:admin_user) { create :admin }
   let(:idea) { create :idea }
   let(:approved_idea) { create :approved_idea }
   let(:not_proceeding_idea) { create :idea, status: Idea.statuses[:not_proceeding] }
-  let(:comment) { create :comment }
+  let(:comment) { create :comment, user: default_user }
 
   context 'As a logged in user' do
     before { sign_in default_user }
 
     describe 'GET /comments' do
       it 'returns a list of comments' do
-        create :comment, idea_id: idea.id
-        create :comment, body: 'Comment 2', idea_id: idea.id
+        create :comment, idea_id: idea.id, user: default_user
+        create :comment, body: 'Comment 2', idea_id: idea.id, user: default_user
         get idea_comments_path(idea)
         expect(response.body).to include('Comment 1')
         expect(response.body).to include('Comment 2')


### PR DESCRIPTION
Changed comments to include users when getting records so that we can
show the user email address without querying the DB again.
Also removed idea from the comments table as you are already on the idea
when you view this.

Tests updated to reflect the comment must include a user as well.