### PR TITLE
Add functionality to send email when the status of an idea is updated

### DIFF
--- a/app/mailers/idea_mailer.rb
+++ b/app/mailers/idea_mailer.rb
@@ -7,4 +7,11 @@ class IdeaMailer < GovukNotifyRails::Mailer
     set_personalisation(title: idea.title)
     mail(to: user.email)
   end
+
+  def status_change_email_template(user, idea)
+    template = 'd816f609-bc00-4f79-961c-da93ffdb8471'
+    set_template(template)
+    set_personalisation(title: idea.title, status: idea.status)
+    mail(to: user.email)
+  end
 end

--- a/app/mailers/idea_mailer.rb
+++ b/app/mailers/idea_mailer.rb
@@ -11,7 +11,7 @@ class IdeaMailer < GovukNotifyRails::Mailer
   def status_change_email_template(user, idea)
     template = 'd816f609-bc00-4f79-961c-da93ffdb8471'
     set_template(template)
-    set_personalisation(title: idea.title, status: idea.status)
+    set_personalisation(title: idea.title, status: t(idea.status))
     mail(to: user.email)
   end
 end

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -19,7 +19,7 @@ class Idea < ApplicationRecord
   validates :involvement, presence: true, if: :submitted?
   validates :review_date, future: true
   before_validation :update_review_date
-  after_update :send_assigned_user_email
+  after_update :send_update_notifications
 
   def submitted?
     submission_date.present?
@@ -120,8 +120,10 @@ class Idea < ApplicationRecord
 
   private
 
-  def send_assigned_user_email
+  def send_update_notifications
     IdeaMailer.assigned_idea_email_template(assigned_user, self).deliver_now if saved_change_to_assigned_user_id?
+
+    IdeaMailer.status_change_email_template(User.find(user_id), self).deliver_now if saved_change_to_status?
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/spec/mailers/idea_mailer_spec.rb
+++ b/spec/mailers/idea_mailer_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe IdeaMailer, type: :mailer do
     it 'sets the body' do
       expect(mail.body).to match("This is a GOV.UK Notify email with template #{template}")
       expect(mail.body).to have_text(idea.title)
-      expect(mail.body).to have_text(idea.status)
+      expect(mail.body).to have_text(t(idea.status))
     end
 
     it 'sets the template' do

--- a/spec/mailers/idea_mailer_spec.rb
+++ b/spec/mailers/idea_mailer_spec.rb
@@ -26,4 +26,29 @@ RSpec.describe IdeaMailer, type: :mailer do
       expect(mail.govuk_notify_template).to eq(template)
     end
   end
+
+  describe 'Status Update Email' do
+    let(:user) { build :user }
+    let(:idea) { build :idea, title: 'New idea', user_id: user.id }
+    let(:template) { 'd816f609-bc00-4f79-961c-da93ffdb8471' }
+    let(:mail) { described_class.status_change_email_template(user, idea) }
+
+    it 'is a govuk_notify delivery' do
+      expect(mail.delivery_method).to be_a(GovukNotifyRails::Delivery)
+    end
+
+    it 'sets the recipient' do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it 'sets the body' do
+      expect(mail.body).to match("This is a GOV.UK Notify email with template #{template}")
+      expect(mail.body).to have_text(idea.title)
+      expect(mail.body).to have_text(idea.status)
+    end
+
+    it 'sets the template' do
+      expect(mail.govuk_notify_template).to eq(template)
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,6 +67,7 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Devise::Test::IntegrationHelpers, type: :system
+  config.include AbstractController::Translation
 
   config.before(:each, type: :system) do
     driven_by :rack_test

--- a/spec/system/update_status_spec.rb
+++ b/spec/system/update_status_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Update status', type: :system do
       visit edit_idea_path(idea)
       expect(page).to have_select('idea_status')
       select 'Approved', from: 'idea_status'
+      expect_any_instance_of(IdeaMailer).to receive(:status_change_email_template).and_call_original
       click_button 'Update Idea'
       idea.reload
       expect(idea.status).to eq('approved')


### PR DESCRIPTION
#### What
Send an email when the status of an idea is updated

#### Ticket
GI-47 https://dsdmoj.atlassian.net/jira/software/projects/GI/boards/250?selectedIssue=GI-47

#### Why
So that people who have submitted an idea know that the status of the idea their idea has changed.

#### How
1. Added a new template to gov.uk notify
2. Created new method in idea_mailer.rb to generate an email based on the new template id.
3. Changed after_update on idea to call the new idea_mailer method.
4. Added system and idea_mailer specs.

![image](https://user-images.githubusercontent.com/29727304/52419720-901b5380-2ae8-11e9-93ee-3ab63310ee94.png)


