### PR TITLE
Fix coverage issue with review dates

### DIFF
--- a/spec/system/update_review_date_spec.rb
+++ b/spec/system/update_review_date_spec.rb
@@ -29,5 +29,15 @@ RSpec.describe 'Update review date', type: :system do
       expect(page).to have_text('Review date cannot be in the past')
       expect(idea.review_date).to be_nil
     end
+
+    it 'should not be possible to update an idea with an invalid review date' do
+      sign_in admin_user
+      visit edit_idea_path(idea)
+      fill_in('idea_review_year', with: 'text')
+      fill_in('idea_review_month', with: 'text')
+      fill_in('idea_review_day', with: 'text')
+      click_button 'Update Idea'
+      expect(idea.review_date).to be_nil
+    end
   end
 end


### PR DESCRIPTION
Coverage was fine, then randomly wasn't as the rescue wasn't
being called.

This just adds in a test to make sure the rescue works when an exception
is raised.