### PR TITLE
Add requires build_and_test to staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,8 @@ workflows:
           branches:
             ignore: master
     - deploy_staging:
+        requires:
+        - build_and_test
         filters:
           branches:
             only: master


### PR DESCRIPTION
We need to ensure the build and test stage has completed before
deploying to the staging environment