### PR TITLE
Switch to translation for pundit

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,11 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+  def user_not_authorized(exception)
+    policy_name = exception.policy.class.to_s.underscore
+
+    flash[:error] = t "#{policy_name}.#{exception.query}", scope: 'pundit', default: :default
+    redirect_to(idea_path(@idea) || root_path)
+  end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -65,9 +65,4 @@ class CommentsController < ApplicationController
       :body
     )
   end
-
-  def user_not_authorized
-    flash[:alert] = 'You cannot create a comment on this idea'
-    redirect_to(idea_path(@idea) || root_path)
-  end
 end

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -113,9 +113,4 @@ class IdeasController < ApplicationController
       )
     end
   end
-
-  def user_not_authorized
-    flash[:alert] = 'You are not authorised to amend this idea'
-    redirect_to(idea_path(@idea) || root_path)
-  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,6 +59,14 @@ en:
   pims: PIMS
   planning_and_performance: Planning and Performance
   public_defender_service: Public Defender Service
+  pundit:
+    comment_policy:
+      create?: You cannot create a comment on this idea.
+      update?: You cannot edit this comment.
+    default: You cannot perform this action.
+    idea_policy:
+      edit?: You are not authorised to amend this idea.
+      update?: You are not authorised to amend this idea.
   reduced_risk: Reduced Risk
   service_development: Service Development
   staff_engagement: Staff Engagement

--- a/spec/system/edit_idea_spec.rb
+++ b/spec/system/edit_idea_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Editing an idea', type: :system do
     describe 'editing another users idea' do
       it 'should give an error' do
         visit edit_idea_path(idea)
-        expect(page).to have_text('You are not authorised to amend this idea')
+        expect(page).to have_text('You are not authorised to amend this idea.')
       end
     end
 


### PR DESCRIPTION
We were customising the error message in the controller, but this could
only be done once for all the actions.  This method enables us to have a
different error message for each action.