### PR TITLE
GI-131 Validation for delete comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -30,8 +30,11 @@ class CommentsController < ApplicationController
   end
 
   def destroy
-    @comment.destroy
-    redirect_to ideas_url, notice: 'Comment was successfully destroyed.'
+    authorize @comment
+
+    @comment.redacted = true
+    @comment.save!
+    redirect_to idea_path(@comment.idea), notice: 'Comment was successfully deleted.'
   end
 
   def create

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -8,7 +8,7 @@ class CommentPolicy < ApplicationPolicy
   def update?
     return true if user.admin
 
-    record.user == user
+    owner? && record.redacted? == false
   end
 
   def create?
@@ -19,6 +19,12 @@ class CommentPolicy < ApplicationPolicy
     end
   end
 
+  def destroy?
+    return true if user.admin && record.redacted? == false
+
+    owner? && record.redacted? == false
+  end
+
   private
 
   def user_commentable_record?
@@ -27,5 +33,9 @@ class CommentPolicy < ApplicationPolicy
 
   def admin_commentable_record?
     record.approved_by_admin?
+  end
+
+  def owner?
+    record.user == user
   end
 end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -22,7 +22,7 @@ class CommentPolicy < ApplicationPolicy
   def destroy?
     return true if user.admin && record.redacted? == false
 
-    owner? && record.redacted? == false
+    owner? && !record.redacted?
   end
 
   private

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -8,7 +8,7 @@ class CommentPolicy < ApplicationPolicy
   def update?
     return true if user.admin
 
-    owner? && record.redacted? == false
+    owner? && !record.redacted?
   end
 
   def create?
@@ -20,7 +20,7 @@ class CommentPolicy < ApplicationPolicy
   end
 
   def destroy?
-    return true if user.admin && record.redacted? == false
+    return true if user.admin && !record.redacted?
 
     owner? && !record.redacted?
   end

--- a/app/views/comments/_comment_list.html.erb
+++ b/app/views/comments/_comment_list.html.erb
@@ -24,7 +24,7 @@
         </tr>
       <% else %>
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">This comment has been deleted.</td>
+          <td class="govuk-table__cell"><%= t('pundit.comment_policy.deleted') %></td>
           <td class="govuk-table__cell"><%= comment.user.email %></td>
           <td class="govuk-table__cell"><%= t(comment.status_at_comment_time) %></td>
           <td class="govuk-table__cell"><%= comment.created_at %></td>

--- a/app/views/comments/_comment_list.html.erb
+++ b/app/views/comments/_comment_list.html.erb
@@ -10,7 +10,7 @@
   </thead>
   <tbody class="govuk-table__body">
     <% comments.each do |comment| %>
-      <% if comment.redacted == false %>
+      <% if !comment.redacted %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell"><%= comment.body %></td>
           <td class="govuk-table__cell"><%= comment.user.email %></td>

--- a/app/views/comments/_comment_list.html.erb
+++ b/app/views/comments/_comment_list.html.erb
@@ -10,15 +10,26 @@
   </thead>
   <tbody class="govuk-table__body">
     <% comments.each do |comment| %>
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= comment.body %></td>
-        <td class="govuk-table__cell"><%= comment.user.email %></td>
-        <td class="govuk-table__cell"><%= t(comment.status_at_comment_time) %></td>
-        <td class="govuk-table__cell"><%= comment.created_at %></td>
-        <td class="govuk-table__cell"><%= link_to 'Show', idea_comment_path(comment.idea, comment) %></td>
-        <td class="govuk-table__cell"><%= link_to 'Edit', edit_idea_comment_path(comment.idea, comment) %></td>
-        <td class="govuk-table__cell"><%= link_to 'Destroy', idea_comment_path(comment.idea, comment), method: :delete, data: { confirm: 'Are you sure?' } %></td>
-      </tr>
+      <% if comment.redacted == false %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><%= comment.body %></td>
+          <td class="govuk-table__cell"><%= comment.user.email %></td>
+          <td class="govuk-table__cell"><%= t(comment.status_at_comment_time) %></td>
+          <td class="govuk-table__cell"><%= comment.created_at %></td>
+          <td class="govuk-table__cell"><%= link_to 'Show', idea_comment_path(comment.idea, comment) %></td>
+          <td class="govuk-table__cell"><%= link_to 'Edit', edit_idea_comment_path(comment.idea, comment) %></td>
+          <% if policy(comment).destroy? %>
+            <td class="govuk-table__cell"><%= link_to 'Delete', idea_comment_path(comment.idea, comment), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+          <% end %>
+        </tr>
+      <% else %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">This comment has been deleted.</td>
+          <td class="govuk-table__cell"><%= comment.user.email %></td>
+          <td class="govuk-table__cell"><%= t(comment.status_at_comment_time) %></td>
+          <td class="govuk-table__cell"><%= comment.created_at %></td>
+        </tr>
+      <% end %>
     <% end %>
   </tbody>
 </table>

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -3,7 +3,11 @@
 <table class="govuk-table">
   <tr class="govuk-table__row">
     <th class="govuk-table__header" scope="row">Comment:</th>
-    <td class="govuk-table__cell"><%= @comment.body %></td>
+      <% if @comment.redacted == false %>
+        <td class="govuk-table__cell"><%= @comment.body %></td>
+      <% else %>
+        <td class="govuk-table__cell"><%= "This comment has been deleted." %></td>
+      <% end %>
   </tr>
   <tr class="govuk-table__row">
     <th class="govuk-table__header" scope="row">User ID:</th>
@@ -14,5 +18,7 @@
     <td class="govuk-table__cell"><%= t(@comment.status_at_comment_time) %></td>
   </tr>
 </table>
-<%= link_to 'Edit', edit_idea_comment_path(@comment.idea, @comment) %> |
+<% if @comment.redacted == false %>
+  <%= link_to 'Edit', edit_idea_comment_path(@comment.idea, @comment) %>
+<% end %>
 <%= link_to 'Back', idea_path(@comment.idea) %>

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -6,7 +6,7 @@
       <% if @comment.redacted == false %>
         <td class="govuk-table__cell"><%= @comment.body %></td>
       <% else %>
-        <td class="govuk-table__cell"><%= "This comment has been deleted." %></td>
+        <td class="govuk-table__cell"><%= t('pundit.comment_policy.deleted') %></td>
       <% end %>
   </tr>
   <tr class="govuk-table__row">

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -3,7 +3,7 @@
 <table class="govuk-table">
   <tr class="govuk-table__row">
     <th class="govuk-table__header" scope="row">Comment:</th>
-      <% if @comment.redacted == false %>
+      <% if !@comment.redacted %>
         <td class="govuk-table__cell"><%= @comment.body %></td>
       <% else %>
         <td class="govuk-table__cell"><%= t('pundit.comment_policy.deleted') %></td>
@@ -18,7 +18,7 @@
     <td class="govuk-table__cell"><%= t(@comment.status_at_comment_time) %></td>
   </tr>
 </table>
-<% if @comment.redacted == false %>
+<% if !@comment.redacted %>
   <%= link_to 'Edit', edit_idea_comment_path(@comment.idea, @comment) %>
 <% end %>
 <%= link_to 'Back', idea_path(@comment.idea) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,7 @@ en:
   pundit:
     comment_policy:
       create?: You cannot create a comment on this idea.
+      destroy?: You cannot delete this comment.
       update?: You cannot edit this comment.
     default: You cannot perform this action.
     idea_policy:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,7 @@ en:
   pundit:
     comment_policy:
       create?: You cannot create a comment on this idea.
+      deleted: This comment has been deleted.
       destroy?: You cannot delete this comment.
       update?: You cannot edit this comment.
     default: You cannot perform this action.

--- a/db/migrate/20190305133226_add_redacted_to_comments.rb
+++ b/db/migrate/20190305133226_add_redacted_to_comments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRedactedToComments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :comments, :redacted, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_19_161229) do
+ActiveRecord::Schema.define(version: 2019_03_05_133226) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2019_02_19_161229) do
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.bigint "idea_id"
+    t.boolean "redacted", default: false
     t.index ["idea_id"], name: "index_comments_on_idea_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end

--- a/db/seeds/non_prod_seeds.rb
+++ b/db/seeds/non_prod_seeds.rb
@@ -81,7 +81,8 @@ Idea.find_each do |idea|
     user = User.offset(rand(User.count)).first
     idea.comments.create!(
       body: Faker::ChuckNorris.fact,
-      user: user
+      user: user,
+      redacted: false
     )
   end
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     association :user, factory: :user, strategy: :build
     association :idea, factory: :idea, strategy: :build
     body { 'Comment 1' }
+    redacted { false }
   end
 end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -53,9 +53,16 @@ RSpec.describe 'Comments', type: :request do
       end
 
       describe 'DELETE /comment' do
-        it 'deletes the comment' do
+        it 'deletes own comment' do
           delete idea_comment_path(comment.idea, comment)
-          expect(Comment.exists?(comment.id)).to eq false
+          comment.reload
+          expect(comment.redacted?).to eq true
+        end
+
+        it 'deletes another users comment' do
+          delete idea_comment_path(admin_comment.idea, admin_comment)
+          admin_comment.reload
+          expect(admin_comment.redacted?).to eq false
         end
       end
 
@@ -140,6 +147,20 @@ RSpec.describe 'Comments', type: :request do
           comment.reload
           expect(comment.body).to eq('Changed comment')
         end
+      end
+    end
+
+    describe 'DELETE /comment' do
+      it 'deletes anther users comment' do
+        delete idea_comment_path(comment.idea, comment)
+        comment.reload
+        expect(comment.redacted?).to eq true
+      end
+
+      it 'deletes ownd users comment' do
+        delete idea_comment_path(admin_comment.idea, admin_comment)
+        admin_comment.reload
+        expect(admin_comment.redacted?).to eq true
       end
     end
   end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -151,13 +151,13 @@ RSpec.describe 'Comments', type: :request do
     end
 
     describe 'DELETE /comment' do
-      it 'deletes anther users comment' do
+      it 'deletes another users comment' do
         delete idea_comment_path(comment.idea, comment)
         comment.reload
         expect(comment.redacted?).to eq true
       end
 
-      it 'deletes ownd users comment' do
+      it 'deletes own users comment' do
         delete idea_comment_path(admin_comment.idea, admin_comment)
         admin_comment.reload
         expect(admin_comment.redacted?).to eq true

--- a/spec/system/delete_comment_spec.rb
+++ b/spec/system/delete_comment_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Delete a comment', type: :system do
+  let(:default_user) { create :user }
+  let(:admin_user) { create :admin }
+  let(:other_user) { create :user, email: 'test@justice.gov.uk' }
+  let(:approved_idea) { create :approved_idea, user: other_user }
+  let(:comment) { create :comment, idea: approved_idea, user: default_user }
+  let(:admin_comment) { create :comment, idea: approved_idea, user: admin_user }
+
+  context 'a logged in user' do
+    before do
+      sign_in default_user
+    end
+
+    context 'on the idea show page with comments' do
+      describe 'deleting their own comment' do
+        it 'deletes a comment when clicking on the delete link' do
+          comment
+          visit idea_path(approved_idea)
+          click_on 'Delete'
+          expect(page).to have_text('This comment has been deleted')
+        end
+      end
+    end
+
+    context 'on the idea show page with comments' do
+      describe 'deleting another users comment' do
+        it 'does not delete a comment when clicking on the delete link' do
+          admin_comment
+          visit idea_path(approved_idea)
+          expect(page).to_not have_link('Delete')
+        end
+      end
+    end
+  end
+
+  context 'a logged in admin user' do
+    before do
+      sign_in admin_user
+    end
+
+    context 'on the idea show page with comments' do
+      describe 'deleting their own comment' do
+        it 'deletes a comment when clicking on the delete link' do
+          admin_comment
+          visit idea_path(approved_idea)
+          click_on 'Delete'
+          expect(page).to have_text('This comment has been deleted')
+        end
+      end
+    end
+
+    context 'on the idea show page with comments' do
+      describe 'deleting another users comment' do
+        it 'does not delete a comment when clicking on the delete link' do
+          comment
+          visit idea_path(approved_idea)
+          click_on 'Delete'
+          expect(page).to have_text('This comment has been deleted')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add validation for delete comments.  Users can delete their own comment,
and admin users can delete anyones comment.

When a comment is deleted it is actually redacted, so the page displays
"This comment has been deleted" but the comment still exists in the
database only with a redacted flag set to true.