### PR TITLE
Add author to idea show page

### DIFF
--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -1,6 +1,10 @@
 <% title "Idea" %>
 <table class="govuk-table">
   <tr class="govuk-table__row">
+    <th class="govuk-table__header" scope="row">Author:</th>
+    <td class="govuk-table__cell"><%= @idea.user.email %></td>
+  </tr>
+  <tr class="govuk-table__row">
     <th class="govuk-table__header" scope="row">Area of Interest:</th>
     <td class="govuk-table__cell"><%= t(@idea.area_of_interest) %></td>
   </tr>

--- a/spec/system/add_comment_spec.rb
+++ b/spec/system/add_comment_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 RSpec.describe 'Add a comment', type: :system do
   let(:default_user) { create :user }
-  let(:idea) { create :idea }
-  let(:approved_idea) { create :approved_idea }
+  let(:idea) { create :idea, user: default_user }
+  let(:approved_idea) { create :approved_idea, user: default_user }
   let(:comment) { create :comment, user: default_user }
 
   context 'a logged in user' do

--- a/spec/system/add_vote_spec.rb
+++ b/spec/system/add_vote_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 RSpec.describe 'Add a vote', type: :system do
   let(:default_user) { create :user }
-  let(:idea) { create :idea }
-  let(:approved_idea) { create :approved_idea }
+  let(:idea) { create :idea, user: default_user }
+  let(:approved_idea) { create :approved_idea, user: default_user }
 
   context 'a logged in user' do
     before { sign_in default_user }

--- a/spec/system/assign_idea_spec.rb
+++ b/spec/system/assign_idea_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Assign idea', type: :system do
   let(:default_user) { create :user }
   let(:admin_user) { create :admin }
-  let(:idea) { create :idea }
+  let(:idea) { create :idea, user: default_user }
 
   describe 'user creating an idea' do
     it 'should not be possible to assign the idea' do

--- a/spec/system/idea_submission_spec.rb
+++ b/spec/system/idea_submission_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Ideas submission', type: :system do
   let(:default_user) { create :user }
-  let(:idea) { create :idea }
+  let(:idea) { create :idea, user: default_user }
   let(:complete_idea) { create :complete_idea, user: default_user }
 
   before do

--- a/spec/system/update_status_spec.rb
+++ b/spec/system/update_status_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Update status', type: :system do
   let(:default_user) { create :user }
   let(:admin_user) { create :admin }
-  let(:idea) { create :idea }
+  let(:idea) { create :idea, user: default_user }
 
   describe 'user updating an idea' do
     it 'should not be possible to update the status of the idea' do


### PR DESCRIPTION
Just noticed that the author was not on the show page, this would make
it difficult for admin users looking at ideas to easily see who created
the idea.

Tests updated as they were failing without a valid user associated with
and idea.